### PR TITLE
FIX: wrong root handling 

### DIFF
--- a/src/core/fetch-backend.ts
+++ b/src/core/fetch-backend.ts
@@ -30,6 +30,9 @@ export class FetchBackend implements PolyfeaBackend {
             const basePath = baseURI.pathname;
             if (path.startsWith(basePath)) {
                 path = './' + path.substring(basePath.length);
+            } else if (basePath.endsWith("/") && path === basePath.substring(0, basePath.length - 1)) {
+                // use case where user navigates to base path without trailing slash
+                path = './';
             }
         }
 

--- a/src/core/static-backend.ts
+++ b/src/core/static-backend.ts
@@ -11,8 +11,15 @@ export class StaticBackend implements PolyfeaBackend {
             if (api.length === 0) {
                 api = "./polyfea";
             }
+            polyfeaApi = new PolyfeaApi(new Configuration({ 
+                basePath: new URL(
+                    api, new URL(
+                        globalThis.document?.baseURI || "/", 
+                        globalThis.location?.href || "http://localhost")
+                ).href }));
             polyfeaApi = new PolyfeaApi(new Configuration({ basePath: api }));
         } else if (api instanceof Configuration) {
+
             polyfeaApi = new PolyfeaApi(api as Configuration);
         } else {
             polyfeaApi = api as PolyfeaApi;
@@ -29,6 +36,9 @@ export class StaticBackend implements PolyfeaBackend {
             const basePath = baseURI.pathname;
             if (path.startsWith(basePath)) {
                 path = './' + path.substring(basePath.length);
+            } else if (basePath.endsWith("/") && path === basePath.substring(0, basePath.length - 1)) {
+                // use case where user navigates to base path without trailing slash
+                path = './';
             }
         }
 

--- a/src/core/tests/fetch-backend.spec.ts
+++ b/src/core/tests/fetch-backend.spec.ts
@@ -91,6 +91,30 @@ test('getContextArea: Path value is relative to base href', async () => {
     expect(contextArea).toStrictEqual(expectedContextArea);
 });
 
+test('getContextArea: Path value is relative to base href, no trailing slash', async () => {
+    // given
+    const fetchMock = FetchMock.sandbox();
+    fetchMock.get('http://localhost:8080/polyfea/context-area/test?path=.%2F', expectedContextArea);
+
+    const w = (globalThis as unknown as Window);
+    globalThis.location?.assign('http://localhost:8080/ui');
+    const baseHref = w.document.createElement('base');
+    baseHref.setAttribute('href', '/ui/');
+    w.document.head.appendChild(baseHref);
+
+    const config = new Configuration({
+        basePath: 'http://localhost:8080/polyfea',
+        fetchApi: fetchMock as unknown as FetchAPI
+    });
+
+    // when
+    const sut = new FetchBackend(config);
+    const contextArea = await firstValueFrom(sut.getContextArea('test'));
+
+    // then
+    expect(contextArea).toStrictEqual(expectedContextArea);
+});
+
 test('getContextArea: Fetched Context areas requests are stored in local storage for faster retrieval', async () => {
     // given
     const fetchMock = FetchMock.sandbox();

--- a/src/core/tests/static-backend.spec.ts
+++ b/src/core/tests/static-backend.spec.ts
@@ -51,6 +51,25 @@ beforeEach(() => {
                         }
                     ],
                 }
+            },
+
+            {
+                name: 'test-root',
+                path: '^(\\./)?$',
+                contextArea: {
+                    elements: [
+                        {
+                            microfrontend: 'root',
+                            tagName: 'my-element',
+                            attributes: {
+                                'some': 'root'
+                            },
+                            style: {
+                                'some': 'root'
+                            }
+                        }
+                    ],
+                }
             }
         ],
         microfrontends: {
@@ -105,7 +124,7 @@ test('getContextArea: Context Area provided', async () => {
 test('getContextArea: Path value is relative to base href', async () => {
     // given
     const fetchMock = FetchMock.sandbox();
-    fetchMock.get('http://localhost:8080/polyfea/static-config', expectedConfig);
+    fetchMock.get('http://localhost:8080/ui/polyfea/static-config', expectedConfig);
 
     const w = (globalThis as unknown as Window);
     globalThis.location?.assign('http://localhost:8080/ui/test-path');
@@ -114,7 +133,7 @@ test('getContextArea: Path value is relative to base href', async () => {
     w.document.head.appendChild(baseHref);
 
     const config = new Configuration({
-        basePath: 'http://localhost:8080/polyfea',
+        basePath: 'http://localhost:8080/ui/polyfea',
         fetchApi: fetchMock as unknown as FetchAPI
     });
 
@@ -128,6 +147,37 @@ test('getContextArea: Path value is relative to base href', async () => {
 
         expect(contextArea).toStrictEqual({
             elements: expectedConfig.contextAreas[1].contextArea?.elements,
+            microfrontends: expectedConfig.microfrontends
+        });
+    }
+});
+
+test('getContextArea: Path value is relative to base href, when missing trailing slash', async () => {
+    // given
+    const fetchMock = FetchMock.sandbox();
+    fetchMock.get('http://localhost:8080/ui/polyfea/static-config', expectedConfig);
+
+    const w = (globalThis as unknown as Window);
+    globalThis.location?.assign('http://localhost:8080/ui');
+    const baseHref = w.document.createElement('base');
+    baseHref.setAttribute('href', '/ui/');
+    w.document.head.appendChild(baseHref);
+
+    const config = new Configuration({
+        basePath: 'http://localhost:8080/ui/polyfea',
+        fetchApi: fetchMock as unknown as FetchAPI
+    });
+
+    // when
+    const sut = new StaticBackend(config);
+    const contextArea = await firstValueFrom(sut.getContextArea('test-root'));
+
+    // then
+    assert(expectedConfig.contextAreas);
+    if (expectedConfig.contextAreas) {
+
+        expect(contextArea).toStrictEqual({
+            elements: expectedConfig.contextAreas[2].contextArea?.elements,
             microfrontends: expectedConfig.microfrontends
         });
     }


### PR DESCRIPTION
More gracefull behaviour if e.g. `<base href="/ui/">` but user uses `/ui` without trailing slash